### PR TITLE
Fix admin training Firebase config

### DIFF
--- a/admin-training.html
+++ b/admin-training.html
@@ -114,7 +114,7 @@
       apiKey: "AIzaSyBm7Yc5VNCRmfMf6Kl-_Ut7mpQotVlKMXU",
       authDomain: "pyb-fitness-web-app.firebaseapp.com",
       projectId: "pyb-fitness-web-app",
-      storageBucket: "pyb-fitness-web-app.firebasestorage.app",
+      storageBucket: "pyb-fitness-web-app.appspot.com",
       messagingSenderId: "151750048787",
       appId: "1:151750048787:web:a82038a64d1a598921d1ba"
     };


### PR DESCRIPTION
## Summary
- correct Firebase storageBucket URL in `admin-training.html` to match the other pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68878468da48832c9ad069dac881ff21