### PR TITLE
Fix merch page link to More page

### DIFF
--- a/client-merch.html
+++ b/client-merch.html
@@ -90,7 +90,7 @@
     <a href="client-programming.html">Programming</a>
     <a href="client-training.html">Training</a>
     <a href="client-merch.html" class="active">Merch</a>
-    <a href="more.html">More</a>
+    <a href="client-more.html">More</a>
   </nav>
 
   <script type="module">


### PR DESCRIPTION
## Summary
- update the "More" navigation link on `client-merch.html` to use the proper client page

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_688784f22498832cb4466aef45a78f86