### PR TITLE
Add pytest navigation link tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# PYB Fitness Web App
+
+This repository contains the static HTML pages for the PYB Fitness application.
+
+## Running the tests
+
+The project uses `pytest` together with `beautifulsoup4` for HTML validation tests.
+Install the test dependencies and run `pytest` from the repository root:
+
+```bash
+pip install pytest beautifulsoup4
+pytest
+```
+
+The provided test checks that all navigation links in each HTML page point to
+files that actually exist in the repository.

--- a/tests/test_nav_links.py
+++ b/tests/test_nav_links.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+from bs4 import BeautifulSoup
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+HTML_FILES = list(ROOT.glob('*.html'))
+
+@pytest.mark.parametrize('html_file', HTML_FILES)
+def test_nav_links_exist(html_file):
+    """Ensure all navigation links point to existing files."""
+    soup = BeautifulSoup(html_file.read_text(encoding='utf-8'), 'html.parser')
+    for nav in soup.find_all('nav'):
+        for a in nav.find_all('a', href=True):
+            href = a['href']
+            if href.startswith(('http://', 'https://', 'mailto:')):
+                continue
+            target = href.split('#', 1)[0].split('?', 1)[0]
+            if not target:
+                continue
+            assert (ROOT / target).exists(), f"{html_file.name}: broken link {href}"


### PR DESCRIPTION
## Summary
- set up pytest and bs4-based test
- check that nav links reference existing files
- document running tests in new README

## Testing
- `pytest -q` *(fails: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_688784f44928832cb28c10c583c76e0a